### PR TITLE
Migrate to custom pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,42 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v1
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          # Upload entire repository
+          path: '.'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@main

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,5 +1,4 @@
-# Simple workflow for deploying static content to GitHub Pages
-name: Deploy static content to Pages
+name: Deploy to GitHub Pages
 
 on:
   # Runs on pushes targeting the default branch
@@ -21,22 +20,34 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Single deploy job since we're just deploying
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  # Build job
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup Pages
         uses: actions/configure-pages@v1
+      - name: Setup Node
+        uses: actions/setup-node@v3
+      - name: Install TailwindCSS
+        run: npm install -D tailwindcss
+      - name: Build with TailwindCSS
+        run: npx tailwindcss -i ./assets/css/input.css -o ./assets/css/output.css --watch
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:
           # Upload entire repository
           path: '.'
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@main
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install TailwindCSS
         run: npm install -D tailwindcss
       - name: Build with TailwindCSS
-        run: npx tailwindcss -i ./assets/css/input.css -o ./assets/css/output.css --watch
+        run: npx tailwindcss -i ./assets/css/input.css -o ./assets/css/output.css
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:


### PR DESCRIPTION
GitHub has just introduced [custom workflows for publishing to GitHub pages](https://github.blog/changelog/2022-07-27-github-pages-custom-github-actions-workflows-beta/).

By levering this feature, we can avoid committing compiled files, which can be prone to developer error, forgetfulness or compile-time inconsistencies; and instead have GitHub actions compile these just before publishing.